### PR TITLE
Add Flask/Celery demo app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# py-test
+# Demo Application
+
+This repository contains a minimal demonstration app that uses **Flask**, **SQLAlchemy**, and **Celery**. It stores users in a SQLite database and processes a background task whenever a user is created.
+
+## Requirements
+
+Install dependencies with pip:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running the application
+
+1. Ensure Redis is running on `localhost:6379` for Celery.
+2. Start the Flask application:
+
+```bash
+python run.py
+```
+
+3. In a separate terminal, run Celery:
+
+```bash
+celery -A demo.tasks worker --loglevel=info
+```
+
+You can then send `POST /users` requests with JSON `{"name": "Alice"}` to create users and trigger the background task.

--- a/demo/__init__.py
+++ b/demo/__init__.py
@@ -1,0 +1,43 @@
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+
+# SQLAlchemy instance
+
+db = SQLAlchemy()
+
+def create_app():
+    app = Flask(__name__)
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///demo.db'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    db.init_app(app)
+
+    with app.app_context():
+        from . import models
+        db.create_all()
+
+    from . import tasks
+
+    @app.route('/')
+    def index():
+        return {'message': 'Demo app running'}
+
+    @app.route('/users', methods=['POST'])
+    def create_user():
+        from flask import request
+        data = request.get_json() or {}
+        name = data.get('name')
+        if not name:
+            return {'error': 'Name required'}, 400
+        user = models.User(name=name)
+        db.session.add(user)
+        db.session.commit()
+        # enqueue background task
+        tasks.send_welcome_email.delay(user.id)
+        return {'id': user.id, 'name': user.name}, 201
+
+    @app.route('/users')
+    def list_users():
+        users = models.User.query.all()
+        return {'users': [{'id': u.id, 'name': u.name} for u in users]}
+
+    return app

--- a/demo/app.py
+++ b/demo/app.py
@@ -1,0 +1,6 @@
+from . import create_app
+
+app = create_app()
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/demo/models.py
+++ b/demo/models.py
@@ -1,0 +1,5 @@
+from . import db
+
+class User(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(128), nullable=False)

--- a/demo/tasks.py
+++ b/demo/tasks.py
@@ -1,0 +1,13 @@
+from celery import Celery
+from . import db
+from .models import User
+
+celery = Celery('demo', broker='redis://localhost:6379/0')
+
+@celery.task
+def send_welcome_email(user_id):
+    user = User.query.get(user_id)
+    if user:
+        print(f"Sending welcome email to {user.name}")
+        return True
+    return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Flask
+SQLAlchemy
+celery
+redis
+pytest

--- a/run.py
+++ b/run.py
@@ -1,0 +1,4 @@
+from demo.app import app
+
+if __name__ == '__main__':
+    app.run()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,31 @@
+import os
+import pytest
+from demo import create_app, db
+from demo.models import User
+
+@pytest.fixture
+def app(tmp_path):
+    # configure app to use temporary database
+    test_db = tmp_path / "test.db"
+    flask_app = create_app()
+    flask_app.config['SQLALCHEMY_DATABASE_URI'] = f"sqlite:///{test_db}"
+
+    with flask_app.app_context():
+        db.create_all()
+        yield flask_app
+        db.drop_all()
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def test_create_user(client):
+    response = client.post('/users', json={'name': 'Test'})
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data['name'] == 'Test'
+    # ensure user stored
+    response = client.get('/users')
+    users = response.get_json()['users']
+    assert any(u['name'] == 'Test' for u in users)


### PR DESCRIPTION
## Summary
- add a simple Flask app using SQLAlchemy
- use Celery for background tasks
- include test for creating a user

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'demo')*

------
https://chatgpt.com/codex/tasks/task_e_684999004a348324b346e659a9a3f36d