### PR TITLE
Implement crypto trading signals platform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY . .
+RUN pip install --no-cache-dir -r requirements.txt
+CMD ["python", "run.py"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# Demo Application
+# Crypto Trading Signals Platform
 
-This repository contains a minimal demonstration app that uses **Flask**, **SQLAlchemy**, and **Celery**. It stores users in a SQLite database and processes a background task whenever a user is created.
+This project provides a small crypto trading signals API.  It exposes REST
+endpoints for registering users and retrieving calculated signals for a trading
+pair.  Price data is fetched from public APIs and indicators such as moving
+averages and RSI are computed in background Celery tasks.  Signals can also be
+pushed over WebSockets using **Flask-SocketIO**.
 
 ## Requirements
 
@@ -12,7 +16,7 @@ pip install -r requirements.txt
 
 ## Running the application
 
-1. Ensure Redis is running on `localhost:6379` for Celery.
+1. Ensure Redis is available (Docker Compose provides a ready to use setup).
 2. Start the Flask application:
 
 ```bash
@@ -22,7 +26,7 @@ python run.py
 3. In a separate terminal, run Celery:
 
 ```bash
-celery -A demo.tasks worker --loglevel=info
+celery -A crypto_signals.tasks worker --loglevel=info
 ```
 
-You can then send `POST /users` requests with JSON `{"name": "Alice"}` to create users and trigger the background task.
+You can then send `POST /register` requests with JSON `{"email": "user@example.com"}` to create users.  Signals for a pair can be retrieved from `/signals/<pair>`.

--- a/crypto_signals/__init__.py
+++ b/crypto_signals/__init__.py
@@ -1,0 +1,31 @@
+import os
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from flask_socketio import SocketIO
+from celery import Celery
+
+
+db = SQLAlchemy()
+# SocketIO used for optional live updates via WebSocket
+socketio = SocketIO(message_queue=os.getenv('REDIS_URL', 'redis://localhost:6379/0'))
+
+celery = Celery(__name__)
+celery.conf.broker_url = os.getenv('CELERY_BROKER_URL', 'redis://localhost:6379/0')
+celery.conf.result_backend = os.getenv('CELERY_RESULT_BACKEND', celery.conf.broker_url)
+celery.conf.task_always_eager = os.getenv('CELERY_TASK_ALWAYS_EAGER', 'True') == 'True'
+
+
+def create_app():
+    app = Flask(__name__)
+    app.config['SQLALCHEMY_DATABASE_URI'] = os.getenv('DATABASE_URL', 'sqlite:///crypto.db')
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    db.init_app(app)
+
+    with app.app_context():
+        from . import models
+        db.create_all()
+
+    from .api import bp
+    app.register_blueprint(bp)
+
+    return app

--- a/crypto_signals/api.py
+++ b/crypto_signals/api.py
@@ -1,0 +1,37 @@
+from flask import Blueprint, request
+from .models import User, Signal
+from . import db
+
+bp = Blueprint('api', __name__)
+
+
+@bp.route('/register', methods=['POST'])
+def register():
+    data = request.get_json() or {}
+    email = data.get('email')
+    if not email:
+        return {'error': 'email required'}, 400
+    user = User(email=email, telegram_id=data.get('telegram_id'))
+    db.session.add(user)
+    db.session.commit()
+    return {'id': user.id, 'email': user.email}, 201
+
+
+@bp.route('/signals/<pair>')
+def get_signals(pair):
+    signals = (Signal.query.filter_by(pair=pair)
+               .order_by(Signal.timestamp.desc())
+               .limit(10)
+               .all())
+    return {
+        'pair': pair,
+        'signals': [
+            {
+                'timestamp': s.timestamp.isoformat(),
+                'ma_short': s.ma_short,
+                'ma_long': s.ma_long,
+                'rsi': s.rsi,
+            }
+            for s in signals
+        ]
+    }

--- a/crypto_signals/models.py
+++ b/crypto_signals/models.py
@@ -1,0 +1,17 @@
+from datetime import datetime
+from . import db
+
+
+class User(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    email = db.Column(db.String(120), unique=True, nullable=False)
+    telegram_id = db.Column(db.String(64))
+
+
+class Signal(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    pair = db.Column(db.String(20), nullable=False)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    ma_short = db.Column(db.Float)
+    ma_long = db.Column(db.Float)
+    rsi = db.Column(db.Float)

--- a/crypto_signals/tasks.py
+++ b/crypto_signals/tasks.py
@@ -1,0 +1,45 @@
+import requests
+from datetime import datetime
+from . import celery, db, socketio
+from .models import Signal
+from .utils import moving_average, compute_rsi
+
+BINANCE_API = 'https://api.binance.com/api/v3/klines'
+
+
+def _fetch_closes(pair, limit=50, interval='1h'):
+    params = {'symbol': pair.upper(), 'interval': interval, 'limit': limit}
+    resp = requests.get(BINANCE_API, params=params, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+    return [float(c[4]) for c in data]  # closing prices
+
+
+@celery.task
+def compute_signals(pair):
+    closes = _fetch_closes(pair)
+    ma_short = moving_average(closes, 7)
+    ma_long = moving_average(closes, 25)
+    rsi = compute_rsi(closes)
+    signal = Signal(pair=pair.upper(), timestamp=datetime.utcnow(),
+                    ma_short=ma_short, ma_long=ma_long, rsi=rsi)
+    db.session.add(signal)
+    db.session.commit()
+    socketio.emit('signal', {
+        'pair': pair.upper(),
+        'ma_short': ma_short,
+        'ma_long': ma_long,
+        'rsi': rsi,
+        'timestamp': signal.timestamp.isoformat()
+    })
+    return signal.id
+
+
+@celery.task
+def notify_users(signal_id):
+    signal = Signal.query.get(signal_id)
+    if not signal:
+        return False
+    # Placeholder for sending notifications
+    print(f"Notify users about {signal.pair} signal at {signal.timestamp}")
+    return True

--- a/crypto_signals/utils.py
+++ b/crypto_signals/utils.py
@@ -1,0 +1,26 @@
+from statistics import mean
+
+
+def moving_average(values, period):
+    if len(values) < period:
+        return None
+    return mean(values[-period:])
+
+
+def compute_rsi(values, period=14):
+    if len(values) <= period:
+        return None
+    gains = []
+    losses = []
+    for i in range(1, period + 1):
+        diff = values[-i] - values[-i - 1]
+        if diff >= 0:
+            gains.append(diff)
+        else:
+            losses.append(-diff)
+    average_gain = mean(gains) if gains else 0
+    average_loss = mean(losses) if losses else 0
+    if average_loss == 0:
+        return 100.0
+    rs = average_gain / average_loss
+    return 100 - (100 / (1 + rs))

--- a/demo/tasks.py
+++ b/demo/tasks.py
@@ -1,8 +1,21 @@
+"""Celery tasks for the demo application.
+
+The Celery configuration is kept very small for the purposes of the tests in
+this repository.  By default tasks are executed eagerly (synchronously) so that
+running the test-suite does not require a running Redis broker.  In a real
+deployment the broker URL can be overridden via the ``CELERY_BROKER_URL``
+environment variable and ``CELERY_TASK_ALWAYS_EAGER`` set to ``False``.
+"""
+
+import os
 from celery import Celery
 from . import db
 from .models import User
 
-celery = Celery('demo', broker='redis://localhost:6379/0')
+celery = Celery('demo')
+celery.conf.broker_url = os.getenv('CELERY_BROKER_URL', 'redis://localhost:6379/0')
+celery.conf.result_backend = os.getenv('CELERY_RESULT_BACKEND', celery.conf.broker_url)
+celery.conf.task_always_eager = os.getenv('CELERY_TASK_ALWAYS_EAGER', 'True') == 'True'
 
 @celery.task
 def send_welcome_email(user_id):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3'
+services:
+  web:
+    build: .
+    command: python run.py
+    volumes:
+      - .:/app
+    ports:
+      - "5000:5000"
+    depends_on:
+      - redis
+  worker:
+    build: .
+    command: celery -A crypto_signals.tasks worker --loglevel=info
+    volumes:
+      - .:/app
+    depends_on:
+      - redis
+  redis:
+    image: redis:alpine
+    ports:
+      - "6379:6379"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ SQLAlchemy
 celery
 redis
 pytest
+requests
+Flask-SocketIO

--- a/run.py
+++ b/run.py
@@ -1,4 +1,8 @@
-from demo.app import app
+"""Entry point for running the crypto signals API."""
+
+from crypto_signals import create_app, socketio
+
+app = create_app()
 
 if __name__ == '__main__':
-    app.run()
+    socketio.run(app, host='0.0.0.0', port=5000)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,12 @@
+from crypto_signals.utils import compute_rsi, moving_average
+
+
+def test_moving_average():
+    data = [1, 2, 3, 4, 5]
+    assert moving_average(data, 3) == 4
+
+
+def test_compute_rsi():
+    prices = list(range(1, 20))
+    rsi = compute_rsi(prices, period=14)
+    assert 0 < rsi <= 100


### PR DESCRIPTION
## Summary
- make Celery eager by default so tests run without Redis
- build a new `crypto_signals` package with REST API and WebSocket support
- fetch price data and compute MA/RSI signals in Celery tasks
- expose `/register` and `/signals/<pair>` endpoints
- add Docker setup and update README
- include tests for new utility helpers

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68499cf874b48324b728de752510f5a6